### PR TITLE
Add Synology Calendar to CalDAV server list

### DIFF
--- a/docs/caldav_create_account.md
+++ b/docs/caldav_create_account.md
@@ -24,3 +24,4 @@ The following is not an exhaustive list of compatible services. If you discover 
 * [Baïkal](http://sabre.io/baikal/)
 * [sabre/dav](http://sabre.io/)
 * [Apple CalendarServer](https://www.calendarserver.org/)
+* [Synology Calendar](https://www.synology.com/en-us/dsm/feature/calendar)


### PR DESCRIPTION
Hi Alex,

Not sure if you prefer pull requests straight away or indeed an email message as the page itself suggests, but I figured the former would be more convenient for you, so here it goes.

As mentioned in https://github.com/tasks/tasks/issues/779#issuecomment-568298036, I've been able to use Tasks with the new(-ish) Synology Calendar server, so it's probably worth adding it to the list to spread the word. As opposed to some of the other apps mentioned so far (e.g. Baikal), this one is an official Synology-supported app, so may be more appealing for those who don't want to install third-party apps onto their NAS.