### PR TITLE
update owncloud partners link

### DIFF
--- a/docs/caldav_intro.md
+++ b/docs/caldav_intro.md
@@ -17,7 +17,7 @@ are missing, outdated, or incorrect, please [send me an e-mail](mailto:support@t
 |   | Hosting | Self-hosting | List sharing | Web interface |
 | -:|:-------:|:------------:|:------------:|:-------------:|
 | [Nextcloud](https://nextcloud.com/providers/) | Free/Paid | ✓ | ✓ [1] | ✓ |
-| [Owncloud](https://owncloud.org/hosting-partners/) | Free/Paid | ✓ | ✓ [1] | ✓ |
+| [Owncloud](https://owncloud.com/partners/find-a-partner/) | Free/Paid | ✓ | ✓ [1] | ✓ |
 | [Fastmail](https://fastmail.com/) | Paid | | | |
 | [Mailbox.org](https://mailbox.org) | Paid | | | ✓ |
 | [fruux](https://fruux.com) | Free/Paid | | ✓ [2] | ✓ |


### PR DESCRIPTION
The previous link was dead. Though, with the new link they definitely don't make it easy to find a partner that does hosting.

Probably because they have their own hosted service now https://owncloud.online/