### PR TITLE
Reflect current state of "Add account" in caldav_intro.md

### DIFF
--- a/docs/caldav_intro.md
+++ b/docs/caldav_intro.md
@@ -58,7 +58,4 @@ the following details:
   * For servers that do not provide a redirect you will need to enter the home
     set URL yourself. This URL will vary by server, but will look something
     like ```https://example.com/remote.php/caldav/calendars/myusername/```
-* **Let server schedule recurring tasks** Some servers, such as mailbox.org,
-  will schedule recurring tasks for you. Enable this option to prevent Tasks
-  from scheduling the next instance of a recurring task
-
+* **Server type**


### PR DESCRIPTION
Commit [e8ad88](https://github.com/tasks/tasks/commit/e8ad88be2188d59822b3951a884ad6d3e9d8155c) introduced the "Server type" setting.

This PR updates the documentation to reflect the change.

I don't know the effect of the option, so I am not describing it.