### PR TITLE
Fix/add info about subtasks

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -19,20 +19,20 @@ the [iCalendar standard](https://en.wikipedia.org/wiki/ICalendar).
 
 The following tables provide a comparison of services and features supported by Tasks.org
 
-|   | Tasks.org | [Google Tasks](sync_google_tasks.md) | [DAVx⁵](sync_davx5.md) | [CalDAV](sync_caldav.md) | [EteSync app](sync_etesync.md) | [EteSync](sync_etesync.md) | [DecSync CC](sync_decsync.md) |
-| -:|:---:|:---------------------------------:|:-------------------:|:---------------------:|:--------------:|:-------:|:------------:|
-| In-app subscription required | Yes¹ |                No                 |         Yes         |          Yes          | Yes | Yes | Yes |
-| Third-party service cost | |               Free                |      Free/Paid      |       Free/Paid       | Paid | Paid | |
-| Open-source self-hosting | |                                   |        Free         |         Free          | Free | Free | |
-| Subtasks | Multi-level |           Single-level            |     Multi-level     |      Multi-level      | Multi-level | Multi-level | Multi-level |
-| Web interface | |                 ✓                 |          ✓²          |           ✓²           | ✓ | ✓ | |
-| Sharing | ✓ |                                   |                     |           ✓           | | ✓ | |
-| [Manual sorting](manual_sort_mode.md) | ✓ |                 ✓                 |          ✓          |           ✓           | ✓ | ✓ | ✓ |
-| Create lists | ✓ |                 ✓                 |                     |           ✓           | | ✓ | |
-| Rename lists | ✓ |                 ✓                 |                     |           ✓           | | ✓ | |
-| Delete lists | ✓ |                 ✓                 |                     |           ✓           | | ✓ | |
-| Change list color | ✓ |                                   |                     |           ✓           | | ✓ | |
-| End-to-end encryption | |                                   |                     |                       | ✓ | ✓ | |
+|   | Tasks.org | [Google Tasks](sync_google_tasks.md) | [DAVx⁵](sync_davx5.md) | [CalDAV](sync_caldav.md) | CalDav-OX | [EteSync app](sync_etesync.md) | [EteSync](sync_etesync.md) | [DecSync CC](sync_decsync.md) |
+| -:|:---:|:---------------------------------:|:-------------------:|:---------------------:|:---------:|:--------------:|:-------:|:------------:|
+| In-app subscription required | Yes¹ |                No                 |         Yes         |          Yes          | | Yes | Yes | Yes |
+| Third-party service cost | |               Free                |      Free/Paid      |       Free/Paid       | | Paid | Paid | |
+| Open-source self-hosting | |                                   |        Free         |         Free          | | Free | Free | |
+| Subtasks | Multi-level |           Single-level            |     Multi-level     |      Multi-level      | | Multi-level | Multi-level | Multi-level |
+| Web interface | |                 ✓                 |          ✓²          |           ✓²           | | ✓ | ✓ | |
+| Sharing | ✓ |                                   |                     |           ✓           | | | ✓ | |
+| [Manual sorting](manual_sort_mode.md) | ✓ |                 ✓                 |          ✓          |           ✓           | | ✓ | ✓ | ✓ |
+| Create lists | ✓ |                 ✓                 |                     |           ✓           | | | ✓ | |
+| Rename lists | ✓ |                 ✓                 |                     |           ✓           | | | ✓ | |
+| Delete lists | ✓ |                 ✓                 |                     |           ✓           | | | ✓ | |
+| Change list color | ✓ |                                   |                     |           ✓           | | | ✓ | |
+| End-to-end encryption | |                                   |                     |                       | | ✓ | ✓ | |
 
 Not all task information synchronizes with third party services. The following
 table lists the metadata currently synchronized with each service

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -46,7 +46,7 @@ table lists the metadata currently synchronized with each service
 | Creation date | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
 | Modification date | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
 | Completion date | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
-| Subtasks | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
+| Subtasks | ✓ |      ✓       | ✓ | ✓ |  | ✓ |
 | Description | ✓ |      ✓³       | ✓ | ✓ | ✓ | ✓ |
 | Priority | ✓ |              | ✓ | ✓ | ✓ | ✓ |
 | Location | ✓ |              | ✓ | ✓ | ✓ | ✓ |

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -37,29 +37,29 @@ The following tables provide a comparison of services and features supported by 
 Not all task information synchronizes with third party services. The following
 table lists the metadata currently synchronized with each service
 
-|   | Tasks.org | Google Tasks | DAVx⁵ / EteSync app / DecSync CC| CalDAV | EteSync |
-| -:|:---:|:------------:|:-----------:|:-------:|:------:|
-| Title | ✓ |      ✓       | ✓ | ✓ | ✓ |
-| Due date | ✓ |      ✓       | ✓ | ✓ | ✓ |
-| Due time | ✓ |              | ✓ | ✓ | ✓ |
-| Start time | ✓ |              | ✓ | ✓ | ✓ |
-| Creation date | ✓ |      ✓       | ✓ | ✓ | ✓ |
-| Modification date | ✓ |      ✓       | ✓ | ✓ | ✓ |
-| Completion date | ✓ |      ✓       | ✓ | ✓ | ✓ |
-| Subtasks | ✓ |      ✓       | ✓ | ✓ | ✓ |
-| Description | ✓ |      ✓³       | ✓ | ✓ | ✓ |
-| Priority | ✓ |              | ✓ | ✓ | ✓ |
-| Location | ✓ |              | ✓ | ✓ | ✓ |
-| Tags | ✓ |              | ✓ | ✓ | ✓ |
-| Recurrence | ✓ |              | ✓ | ✓ | ✓ |
-| Reminders | ✓ |              | ✓ | ✓ | ✓ |
-| Random reminders | |              | | | |
-| Location reminders | |              | | | |
-| Repeat after completion | |              | | | |
-| Attachments | |              | | | |
-| Calendar event | |              | | | |
-| Timer | |              | | | |
-| Comments | |              | | | |
+|   | Tasks.org | Google Tasks | DAVx⁵ / EteSync app / DecSync CC| CalDAV | CalDav-OX | EteSync |
+| -:|:---:|:------------:|:-----------:|:-------:|:---:|:------:|
+| Title | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
+| Due date | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
+| Due time | ✓ |              | ✓ | ✓ | ✓ | ✓ |
+| Start time | ✓ |              | ✓ | ✓ | ✓ | ✓ |
+| Creation date | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
+| Modification date | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
+| Completion date | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
+| Subtasks | ✓ |      ✓       | ✓ | ✓ | ✓ | ✓ |
+| Description | ✓ |      ✓³       | ✓ | ✓ | ✓ | ✓ |
+| Priority | ✓ |              | ✓ | ✓ | ✓ | ✓ |
+| Location | ✓ |              | ✓ | ✓ | ✓ | ✓ |
+| Tags | ✓ |              | ✓ | ✓ | ✓ | ✓ |
+| Recurrence | ✓ |              | ✓ | ✓ | ✓ | ✓ |
+| Reminders | ✓ |              | ✓ | ✓ | ✓ | ✓ |
+| Random reminders | |              | | | | |
+| Location reminders | |              | | | | |
+| Repeat after completion | |              | | | | |
+| Attachments | |              | | | | |
+| Calendar event | |              | | | | |
+| Timer | |              | | | | |
+| Comments | |              | | | | |
 
 ¹ Google Play subscription or [GitHub
 sponsorship](https://github.com/sponsors/abaker) required

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -19,7 +19,7 @@ the [iCalendar standard](https://en.wikipedia.org/wiki/ICalendar).
 
 The following tables provide a comparison of services and features supported by Tasks.org
 
-|   | Tasks.org | [Google Tasks](sync_google_tasks.md) | [DAVx⁵](sync_davx5.md) | [CalDAV](sync_caldav.md) | CalDav-OX | [EteSync app](sync_etesync.md) | [EteSync](sync_etesync.md) | [DecSync CC](sync_decsync.md) |
+|   | Tasks.org | [Google Tasks](sync_google_tasks.md) | [DAVx⁵](sync_davx5.md) | [CalDAV](sync_caldav.md) | [CalDav-OX](sync_caldav.md) | [EteSync app](sync_etesync.md) | [EteSync](sync_etesync.md) | [DecSync CC](sync_decsync.md) |
 | -:|:---:|:---------------------------------:|:-------------------:|:---------------------:|:---:|:--------------:|:-------:|:------------:|
 | In-app subscription required | Yes¹ |                No                 |         Yes         |          Yes          | Yes | Yes | Yes | Yes |
 | Third-party service cost | |               Free                |      Free/Paid      |       Free/Paid       | Free/Paid | Paid | Paid | |

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -20,18 +20,18 @@ the [iCalendar standard](https://en.wikipedia.org/wiki/ICalendar).
 The following tables provide a comparison of services and features supported by Tasks.org
 
 |   | Tasks.org | [Google Tasks](sync_google_tasks.md) | [DAVx⁵](sync_davx5.md) | [CalDAV](sync_caldav.md) | CalDav-OX | [EteSync app](sync_etesync.md) | [EteSync](sync_etesync.md) | [DecSync CC](sync_decsync.md) |
-| -:|:---:|:---------------------------------:|:-------------------:|:---------------------:|:---------:|:--------------:|:-------:|:------------:|
-| In-app subscription required | Yes¹ |                No                 |         Yes         |          Yes          | | Yes | Yes | Yes |
-| Third-party service cost | |               Free                |      Free/Paid      |       Free/Paid       | | Paid | Paid | |
-| Open-source self-hosting | |                                   |        Free         |         Free          | | Free | Free | |
-| Subtasks | Multi-level |           Single-level            |     Multi-level     |      Multi-level      | | Multi-level | Multi-level | Multi-level |
-| Web interface | |                 ✓                 |          ✓²          |           ✓²           | | ✓ | ✓ | |
-| Sharing | ✓ |                                   |                     |           ✓           | | | ✓ | |
-| [Manual sorting](manual_sort_mode.md) | ✓ |                 ✓                 |          ✓          |           ✓           | | ✓ | ✓ | ✓ |
-| Create lists | ✓ |                 ✓                 |                     |           ✓           | | | ✓ | |
-| Rename lists | ✓ |                 ✓                 |                     |           ✓           | | | ✓ | |
-| Delete lists | ✓ |                 ✓                 |                     |           ✓           | | | ✓ | |
-| Change list color | ✓ |                                   |                     |           ✓           | | | ✓ | |
+| -:|:---:|:---------------------------------:|:-------------------:|:---------------------:|:---:|:--------------:|:-------:|:------------:|
+| In-app subscription required | Yes¹ |                No                 |         Yes         |          Yes          | Yes | Yes | Yes | Yes |
+| Third-party service cost | |               Free                |      Free/Paid      |       Free/Paid       | Free/Paid | Paid | Paid | |
+| Open-source self-hosting | |                                   |        Free         |         Free          | Free | Free | Free | |
+| Subtasks | Multi-level |           Single-level            |     Multi-level     |      Multi-level      | Single-level | Multi-level | Multi-level | Multi-level |
+| Web interface | |                 ✓                 |          ✓²          |           ✓²           | ✓² | ✓ | ✓ | |
+| Sharing | ✓ |                                   |                     |           ✓           | ✓ | | ✓ | |
+| [Manual sorting](manual_sort_mode.md) | ✓ |                 ✓                 |          ✓          |           ✓           | ✓ | ✓ | ✓ | ✓ |
+| Create lists | ✓ |                 ✓                 |                     |           ✓           | ✓ | | ✓ | |
+| Rename lists | ✓ |                 ✓                 |                     |           ✓           | ✓ | | ✓ | |
+| Delete lists | ✓ |                 ✓                 |                     |           ✓           | ✓ | | ✓ | |
+| Change list color | ✓ |                                   |                     |           ✓           | ✓ | | ✓ | |
 | End-to-end encryption | |                                   |                     |                       | | ✓ | ✓ | |
 
 Not all task information synchronizes with third party services. The following

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -19,7 +19,7 @@ the [iCalendar standard](https://en.wikipedia.org/wiki/ICalendar).
 
 The following tables provide a comparison of services and features supported by Tasks.org
 
-|   | Tasks.org | [Google Tasks](sync_google_tasks.md) | [DAVx⁵](sync_davx5.md) | [CalDAV](sync_caldav.md) | [CalDav-OX](sync_caldav.md) | [EteSync app](sync_etesync.md) | [EteSync](sync_etesync.md) | [DecSync CC](sync_decsync.md) |
+|   | Tasks.org | [Google Tasks](sync_google_tasks.md) | [DAVx⁵](sync_davx5.md) | [CalDAV](sync_caldav.md) | [CalDav-OX⁴](sync_caldav.md) | [EteSync app](sync_etesync.md) | [EteSync](sync_etesync.md) | [DecSync CC](sync_decsync.md) |
 | -:|:---:|:---------------------------------:|:-------------------:|:---------------------:|:---:|:--------------:|:-------:|:------------:|
 | In-app subscription required | Yes¹ |                No                 |         Yes         |          Yes          | Yes | Yes | Yes | Yes |
 | Third-party service cost | |               Free                |      Free/Paid      |       Free/Paid       | Free/Paid | Paid | Paid | |
@@ -67,6 +67,8 @@ sponsorship](https://github.com/sponsors/abaker) required
 ² In-app subscription required to add two or more Google Task accounts
 
 ³ Limited to 8192 characters
+
+⁴ Caldav-OX refers to OpenXchange's implementation of Caldav, which lacks some features
 
 ### Sync Conditions
 

--- a/docs/sync_caldav.md
+++ b/docs/sync_caldav.md
@@ -13,22 +13,22 @@ The following is not an exhaustive list of compatible services. If any services
 are missing, outdated, or incorrect, please [send me an e-mail](mailto:support@tasks.org), or open a pull request at
 [github.com/tasks/docs](https://github.com/tasks/docs)
 
-|   | Hosting | Self-hosting | List sharing | Web interface |
-| -:|:-------:|:------------:|:------------:|:-------------:|
-| [Nextcloud](https://nextcloud.com/providers/) | Free/Paid | ✓ | ✓ [1] | ✓ |
-| [Owncloud](https://owncloud.com/partners/find-a-partner/) | Free/Paid | ✓ | ✓ [1] | ✓ |
-| [Fastmail](https://fastmail.com/) | Paid | | | |
-| [Mailbox.org](https://mailbox.org) | Paid | | | ✓ |
-| [fruux](https://fruux.com) | Free/Paid | | ✓ [2] | ✓ |
-| [Vikunja](https://vikunja.io/docs/caldav/) | Free/Paid | ✓ | | ✓ |
-| [xandikos](https://xandikos.org) | | ✓ | | |
-| [Radicale](https://radicale.org) | | ✓ | | |
-| [Baïkal](http://sabre.io/baikal/) | | ✓ | | ✓ |
-| [sabre/dav](http://sabre.io/) | | ✓ | | |
-| [Synology Calendar](https://www.synology.com/en-us/dsm/feature/calendar) | | ✓ | | |
-| [Apple CalendarServer](https://www.calendarserver.org/) | | ✓ | | |
-| Microsoft Exchange | Paid [3] | | | |
-| [Office 365](https://office365.com) | Free [3] | | ✓ | ✓ |
+|   | Hosting | Self-hosting | List sharing | Web interface | Backend |
+| -:|:-------:|:------------:|:------------:|:-------------:| :--- |
+| [Nextcloud](https://nextcloud.com/providers/) | Free/Paid | ✓ | ✓ [1] | ✓ | sabre/dav |
+| [Owncloud](https://owncloud.com/partners/find-a-partner/) | Free/Paid | ✓ | ✓ [1] | ✓ | sabre/dav |
+| [Fastmail](https://fastmail.com/) | Paid | | | | Proprietary (Cyrus) |
+| [Mailbox.org](https://mailbox.org) | Paid | | | ✓ | OpenXchange |
+| [fruux](https://fruux.com) | Free/Paid | | ✓ [2] | ✓ | sabre/dav |
+| [Vikunja](https://vikunja.io/docs/caldav/) | Free/Paid | ✓ | | ✓ |  |
+| [xandikos](https://xandikos.org) | | ✓ | | | |
+| [Radicale](https://radicale.org) | | ✓ | | | Radicale |
+| [Baïkal](http://sabre.io/baikal/) | | ✓ | | ✓ | Baïkal (built on sabre/dav) |
+| [sabre/dav](http://sabre.io/) | | ✓ | | | sabre/dav |
+| [Synology Calendar](https://www.synology.com/en-us/dsm/feature/calendar) | | ✓ | | | |
+| [Apple CalendarServer](https://www.calendarserver.org/) | | ✓ | | | Proprietary |
+| Microsoft Exchange | Paid [3] | | | | Proprietary |
+| [Office 365](https://office365.com) | Free [3] | | ✓ | ✓ | Proprietary |
 
 [1]: Not all hosting providers support sharing
 
@@ -57,3 +57,11 @@ the following details:
     set URL yourself. This URL will vary by server, but will look something
     like ```https://example.com/remote.php/caldav/calendars/myusername/```
 * **Server type**
+
+
+### Support for Caldav standards
+- Certain caldav standards are not supported amongst different caldav server backends
+- `sabre/dav` is the backend used by tasks.org cloud
+#### Subtasks
+- subtasks requires a feature called [related-to](https://www.rfc-editor.org/rfc/rfc9253.html#name-related-to)
+- related-to is not supported on OpenXchange based servers


### PR DESCRIPTION
I wanted to add some info about how certain caldav servers don't support `RELATED-TO;RELTYPE=PARENT` , ie subtasks.

This way when choosing a backend people can be better informed about the limitations.

In reference to the conversation https://github.com/tasks/tasks/issues/695